### PR TITLE
Fixed the Score Counter's UpdateScore method

### DIFF
--- a/ProgressCounter/Plugin.cs
+++ b/ProgressCounter/Plugin.cs
@@ -35,7 +35,7 @@ namespace ProgressCounter
         {
             if (scene.buildIndex != 5) return;
             new GameObject("Counter").AddComponent<Counter>();
-            //new GameObject("ScoreCounter").AddComponent<ScoreCounter>();
+            new GameObject("ScoreCounter").AddComponent<ScoreCounter>();
         }
 
         public void OnFixedUpdate()

--- a/ProgressCounter/ScoreCounter.cs
+++ b/ProgressCounter/ScoreCounter.cs
@@ -84,10 +84,9 @@ namespace ProgressCounter
         public void UpdateScore(int score)
         {
             float percent = (float)score / (float)_maxPossibleScore;
-
             if (_objectRatingRecorder != null)
             {
-                List<BeatmapObjectExecutionRating> _ratings = ReflectionUtil.GetPrivateField<List<BeatmapObjectExecutionRating>>(_objectRatingRecorder, "_songObjectExecutionRatings");
+                List<BeatmapObjectExecutionRating> _ratings = ReflectionUtil.GetPrivateField<List<BeatmapObjectExecutionRating>>(_objectRatingRecorder, "_beatmapObjectExecutionRatings");
                 if (_ratings != null)
                 {
                     int notes = 0;


### PR DESCRIPTION
I was really missing the Score Counter (especially on the new 6 minute track) so I dug in and found the protected property name holding the execution ratings had changed with the Beat Saber 0.11.0 refactoring. After swapping it out and re-enabling the `ScoreCounter` in `Plugin.cs`, the Score Counter looks to working as expected.

Thanks for authoring this plugin, it makes my playthroughs a lot less stressful when I know how well I'm doing half way through.